### PR TITLE
Use MathJax from Cloudflare CDN, remove async

### DIFF
--- a/_layouts/default.md
+++ b/_layouts/default.md
@@ -13,7 +13,7 @@
   			tex2jax: {inlineMath: [["$","$"],["\\(","\\)"]]}
 		});
 		</script>
-		<script type="text/javascript" async src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_CHTML">
+		<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.6/MathJax.js?config=TeX-MML-AM_CHTML">
 		</script>
 	{% endif %}
 	{% if page.includes contains 'jquery' %}


### PR DESCRIPTION
The MathJax CDN is [retired](https://www.mathjax.org/cdn-shutting-down/). That means that demos like the simple forward pass will stop working in the future. I've pointed MathJax to a copy from the Cloudflare CDN.

In addition, the `async` attribute on the script means that the page actually has a race condition, where it will show up depending on whether the required JavaScript is already in cache. I've removed the async attribute to make sure the page works on first load.